### PR TITLE
updata Readme CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ function(compile_fbs)
     add_custom_command(OUTPUT ${target_header}
       DEPENDS ${fbs_file}
       COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/include/cvibuilder
-      COMMAND ${FLATBUFFERS_PATH}/bin/flatc -o ${CMAKE_CURRENT_BINARY_DIR}/include/cvibuilder --cpp ${fbs_file}
+      COMMAND ${FLATBUFFERS_PATH}/flatc -o ${CMAKE_CURRENT_BINARY_DIR}/include/cvibuilder --cpp ${fbs_file}
     )
     set(targets ${targets} ${target_header})
   endforeach()

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # cvibuilder
+先决条件： 安装flatbuffers，https://github.com/google/flatbuffers
 
+安装：
+
+cmake -DFLATBUFFERS_PATH=/home/tpu/tpu/flatbuffers .
+make
+输出：
+
+├── include
+│   └── cvibuilder
+│       ├── cvimodel_generated.h
+│       └── parameter_generated.h


### PR DESCRIPTION
When run make，git the error as `/home/tpu/tpu/flatbuffers/bin/flatc: 没有那个文件或目录`，Because flatc is located under/flatbuffers, the bin directory is no longer generated, so updata the CMakeLists and Readme